### PR TITLE
Extend the support range for the `no_proxy` variable

### DIFF
--- a/tests/test-client/src/noProxy.test.ts
+++ b/tests/test-client/src/noProxy.test.ts
@@ -1,0 +1,84 @@
+import * as assert from 'assert';
+import * as vpa from '../../..';
+
+describe("no_proxy value support", () => {
+    const urlWithDomain = "https://example.com/some/path";
+    const urlWithDomainAndPort = "https://example.com:80/some/path";
+    const urlWithSubdomain = "https://internal.example.com/some/path";
+    const urlWithIPv4 = "https://100.0.0.1/some/path";
+    const urlWithIPv4AndPort = "https://100.0.0.1:80/some/path";
+    const urlWithIPv6 = "https://[f182:5b41:6491:49d2:2384:cca9:1ba5:13f1]/some/path";
+
+    const baseParams: vpa.ProxyAgentParams = {
+        resolveProxy: async () => 'PROXY test-http-proxy:3128',
+        getProxyURL: () => undefined,
+        getProxySupport: () => 'override',
+        isAdditionalFetchSupportEnabled: () => true,
+        addCertificatesV1: () => false,
+        addCertificatesV2: () => true,
+        log: console,
+        getLogLevel: () => vpa.LogLevel.Trace,
+        proxyResolveTelemetry: () => undefined,
+        loadAdditionalCertificates: () => Promise.resolve([]),
+        useHostProxy: true,
+        env: {},
+    };
+
+    const testNoProxy = async (expectedOutcome: 'handled' | 'bypassed', testUrl: string, denyList: string[]) => {
+        const { resolveProxyURL } = vpa.createProxyResolver({...baseParams, getNoProxyConfig: () => denyList});
+        const resolvedUrl = await resolveProxyURL(testUrl)
+        const outcome = resolvedUrl === undefined ? 'bypassed' : 'handled';
+        assert.strictEqual(outcome, expectedOutcome, `given a denylist of ${denyList}, proxying ${testUrl} should have been ${expectedOutcome} but was not`);
+    }
+
+    it("proceeds if no denylists are provided", async () => {
+        await testNoProxy('handled', urlWithDomain, []);
+    });
+
+    it("match wildcard", async () => {
+        await testNoProxy('bypassed', urlWithDomain, ["*"]);
+        await testNoProxy('bypassed', urlWithSubdomain, ["*"]);
+        await testNoProxy('bypassed', urlWithIPv4, ["*"]);
+        await testNoProxy('bypassed', urlWithIPv6, ["*"]);
+    });
+
+    it("match direct hostname", async () => {
+        await testNoProxy('bypassed', urlWithDomain, ['example.com']);
+        await testNoProxy('handled', urlWithDomain, ['otherexample.com']);
+        // Technically the following are a suffix match but it's a known behavior in the ecosystem
+        await testNoProxy('bypassed', urlWithDomain, ['.example.com']);
+        await testNoProxy('handled', urlWithDomain, ['.otherexample.com']);
+    });
+
+    it("match hostname suffixes", async () => {
+        await testNoProxy('bypassed', urlWithSubdomain, ['example.com']);
+        await testNoProxy('bypassed', urlWithSubdomain, ['.example.com']);
+        await testNoProxy('handled', urlWithSubdomain, ['otherexample.com']);
+        await testNoProxy('handled', urlWithSubdomain, ['.otherexample.com']);
+    });
+
+    it("match hostname with ports", async () => {
+        await testNoProxy('bypassed', urlWithDomainAndPort, ['example.com:80']);
+        await testNoProxy('handled', urlWithDomainAndPort, ['otherexample.com:80']);
+        await testNoProxy('handled', urlWithDomainAndPort, ['example.com:70']);
+    });
+
+    it("match IP addresses", async () => {
+        await testNoProxy('handled', urlWithIPv4, ['example.com']);
+        await testNoProxy('handled', urlWithIPv6, ['example.com']);
+        await testNoProxy('bypassed', urlWithIPv4, ['100.0.0.1']);
+        await testNoProxy('bypassed', urlWithIPv6, ['f182:5b41:6491:49d2:2384:cca9:1ba5:13f1']);
+    });
+
+    it("match IP addresses with port", async () => {
+        await testNoProxy('bypassed', urlWithIPv4AndPort, ['100.0.0.1:80']);
+        await testNoProxy('handled', urlWithIPv4AndPort, ['100.0.0.1:70']);
+    });
+
+    it("match IP addresses with range deny list", async () => {
+        await testNoProxy('bypassed', urlWithIPv4, ['100.0.0.0/8']);
+        await testNoProxy('handled', urlWithIPv4, ['10.0.0.0/8']);
+        await testNoProxy('bypassed', urlWithIPv6, ['f182:5b41:6491:49d2::0/64']);
+        await testNoProxy('handled', urlWithIPv6, ['100::0/64']);
+    })
+});

--- a/tests/test-client/tsconfig.json
+++ b/tests/test-client/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"compilerOptions": {
 		"module": "commonjs",
-		"target": "es2015",
+		"target": "es2018",
 		"esModuleInterop": true,
 		"strict": true,
 		"resolveJsonModule": true


### PR DESCRIPTION
Imported from https://github.com/microsoft/vscode/pull/206622

Add wider support for the possible values that can be in `no_proxy` (both with values provide via configuration like a vscode setting and from the process environment variable).

Since there is no one true way to process the content of the `no_proxy` value, I tried to follow the most compatible approach as outlined in https://about.gitlab.com/blog/2021/01/27/we-need-to-talk-no-proxy/. See also the man pages of tools like [`curl`](https://linux.die.net/man/1/curl#:~:text=%2D%2Dnoproxy%20%3Cno%2Dproxy%2Dlist%3E) or [`wget`](https://www.gnu.org/software/wget/manual/html_node/Proxies.html#:~:text=same%20URL.-,no_proxy,-This%20variable%20should) for examples.

The PR supports the following options:
- simple wildcard allow with `*`
- equality matching of both hostnames and IP addresses (v4 + v6)
- suffix matching for hostnames
- IP (v4 & v6) range matching (using node's builtin [BlockList](https://nodejs.org/api/net.html#class-netblocklist) class)

Tests were added.