### PR TITLE
Make keepAlive opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 Notable changes will be documented here.
 
+## [0.32.1]
+- Make keepAlive flag opt-in ([microsoft/vscode-proxy-agent#243482](https://github.com/microsoft/vscode/issues/243482))
+
 ## [0.32.0]
 - Check both system certificates settings for `fetch` ([microsoft/vscode-proxy-agent#66](https://github.com/microsoft/vscode-proxy-agent/pull/66))
 

--- a/tests/test-client/src/direct.test.ts
+++ b/tests/test-client/src/direct.test.ts
@@ -158,8 +158,7 @@ describe('Direct client', function () {
 		});
 		assert.ok(seen, 'Original agent not called!');
 	});
-	it.skip('should reuse socket with agent', async function () {
-		// Skipping due to https://github.com/microsoft/vscode/issues/228872.
+	it('should reuse socket with agent', async function () {
 		// https://github.com/microsoft/vscode/issues/173861
 		const { resolveProxyWithRequest: resolveProxy } = vpa.createProxyResolver(directProxyAgentParams);
 		const patchedHttps: typeof https = {


### PR DESCRIPTION
If clients use an agent that is not the default global agent, then use their keepAlive to create proxy agent.
