### PR TITLE
call check server identity from original agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 Notable changes will be documented here.
 
+## [0.32.1]
+- Call checkServerIdentity from original agent
+
 ## [0.32.0]
 - Check both system certificates settings for `fetch` ([microsoft/vscode-proxy-agent#66](https://github.com/microsoft/vscode-proxy-agent/pull/66))
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vscode/proxy-agent",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@vscode/proxy-agent",
-      "version": "0.31.0",
+      "version": "0.32.0",
       "license": "MIT",
       "dependencies": {
         "@tootallnate/once": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vscode/proxy-agent",
-  "version": "0.32.0",
+  "version": "0.32.1",
   "description": "NodeJS http(s) agent implementation for VS Code",
   "main": "out/index.js",
   "types": "out/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -370,6 +370,8 @@ export function createHttpPatch(params: ProxyAgentParams, originals: typeof http
 			// If Agent.options.ca is set to undefined, it overwrites RequestOptions.ca.
 			const originalOptionsCa = isHttps ? (options as https.RequestOptions).ca : undefined;
 			const originalAgentCa = isHttps && originalAgent instanceof originals.Agent && (originalAgent as https.Agent).options && 'ca' in (originalAgent as https.Agent).options && (originalAgent as https.Agent).options.ca;
+			const originalAgentCheckServerIdentity = isHttps && originalAgent instanceof originals.Agent && (originalAgent as https.Agent).options && 'checkServerIdentity' in (originalAgent as https.Agent).options && (originalAgent as https.Agent).options.checkServerIdentity;
+			const originalCheckServerIdentity = originalAgentCheckServerIdentity !== false ? originalAgentCheckServerIdentity : undefined;
 			const originalCa = originalAgentCa !== false ? originalAgentCa : originalOptionsCa;
 			const addCertificatesV1 = !optionsPatched && params.addCertificatesV1() && isHttps && !originalCa;
 
@@ -396,6 +398,7 @@ export function createHttpPatch(params: ProxyAgentParams, originals: typeof http
 					originalAgent: (!useProxySettings || isLocalhost || config === 'fallback') ? originalAgent : undefined,
 					lookupProxyAuthorization: params.lookupProxyAuthorization,
 					// keepAlive: ((originalAgent || originals.globalAgent) as { keepAlive?: boolean }).keepAlive, // Skipping due to https://github.com/microsoft/vscode/issues/228872.
+					checkServerIdentity: (host, cert) => originalCheckServerIdentity?.(host, cert),
 					_vscodeTestReplaceCaCerts: (options as SecureContextOptionsPatch)._vscodeTestReplaceCaCerts,
 				}, opts => new Promise<void>(resolve => addCertificatesToOptionsV1(params, params.addCertificatesV1(), opts, resolve)));
 				agent.protocol = isHttps ? 'https:' : 'http:';


### PR DESCRIPTION
Currently checkServerIdentity arg is ignored which leads to not being able to implement cert pinning feature