### PR TITLE
Add certificate path for Fedora 43

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -875,6 +875,7 @@ const linuxCaCertificatePaths = [
 	'/etc/ssl/certs/ca-certificates.crt', // Debian / Ubuntu / Alpine / Fedora
 	'/etc/ssl/certs/ca-bundle.crt', // Fedora
 	'/etc/ssl/ca-bundle.pem', // OpenSUSE
+	'/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem', // Fedora 43+
 ];
 
 async function readLinuxCaCertificates() {


### PR DESCRIPTION
See https://fedoraproject.org/wiki/Changes/dropingOfCertPemFile for details.
Fixes microsoft/vscode#261433