### PR TITLE
Replace deprecated url.parse in proxy resolution

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -242,9 +242,9 @@ export function createProxyResolver(params: ProxyAgentParams) {
 		}
 	}
 
-	function getCacheKey(url: nodeurl.UrlWithStringQuery) {
+	function getCacheKey(url: nodeurl.URL) {
 		// Expecting proxies to usually be the same per scheme://host:port. Assuming that for performance.
-		return nodeurl.format({ ...url, ...{ pathname: undefined, search: undefined, hash: undefined } });
+		return `${url.protocol}//${url.host}`;
 	}
 	function getCachedProxy(key: string) {
 		checkAndFlushCacheIfNetworkChanged();
@@ -304,7 +304,7 @@ export function createProxyResolver(params: ProxyAgentParams) {
 	}
 
 	function useProxySettings(url: string, req: http.ClientRequest | undefined, stackText: string, callback: (proxy: string | undefined, source: ProxyResolveSource) => void) {
-		const parsedUrl = nodeurl.parse(url); // Coming from Node's URL, sticking with that.
+		const parsedUrl = new nodeurl.URL(url);
 
 		const hostname = parsedUrl.hostname;
 		if (hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1' || hostname === '::ffff:127.0.0.1') {
@@ -1463,5 +1463,4 @@ export function toLogString(args: any[]) {
 			return value;
 		})).join(', ')}]`;
 }
-
 

--- a/tests/src/resolveProxyByURL.test.ts
+++ b/tests/src/resolveProxyByURL.test.ts
@@ -1,4 +1,5 @@
 import * as assert from 'assert';
+import { spawnSync } from 'child_process';
 import { createProxyResolver, LogLevel, ProxyAgentParams } from '../../src';
 
 function createParams(overrides: Partial<ProxyAgentParams>): ProxyAgentParams {
@@ -24,6 +25,46 @@ function createParams(overrides: Partial<ProxyAgentParams>): ProxyAgentParams {
 }
 
 describe('resolveProxyByURL', function () {
+	it('does not emit the legacy URL parser deprecation', async function () {
+		if (process.env['VSCODE_PROXY_AGENT_DEPRECATION_CHILD'] !== '1') {
+			const result = spawnSync(process.execPath, [
+				'--pending-deprecation',
+				require.resolve('mocha/bin/mocha'),
+				'--exit',
+				'-r',
+				'ts-node/register',
+				__filename,
+				'--grep',
+				'legacy URL parser',
+			], {
+				encoding: 'utf8',
+				env: {
+					...process.env,
+					TS_NODE_COMPILER_OPTIONS: JSON.stringify({ types: ['node', 'mocha'] }),
+					VSCODE_PROXY_AGENT_DEPRECATION_CHILD: '1',
+				},
+			});
+			assert.strictEqual(result.status, 0, result.stdout + result.stderr);
+			return;
+		}
+
+		const warnings: Error[] = [];
+		const onWarning = (warning: Error & { code?: string }) => {
+			if (warning.code === 'DEP0169') {
+				warnings.push(warning);
+			}
+		};
+		process.on('warning', onWarning);
+		try {
+			const { resolveProxyByURL } = createProxyResolver(createParams({}));
+			await resolveProxyByURL('https://example.com/path?query=value#fragment');
+			await new Promise<void>(resolve => setImmediate(resolve));
+		} finally {
+			process.off('warning', onWarning);
+		}
+		assert.deepStrictEqual(warnings, []);
+	});
+
 	it('reports localhost as a direct connection', async function () {
 		const { resolveProxyByURL } = createProxyResolver(createParams({}));
 		assert.deepStrictEqual(await resolveProxyByURL('http://localhost:3000/'), {


### PR DESCRIPTION
Fixes the DEP0169 warnings emitted by VS Code agent-host and extension-host fetch paths.

The proxy cache already declares scheme://host:port as its key, so this replaces the legacy parser with WHATWG URL and constructs that same cache key from protocol and host.

The regression runs the resolver under --pending-deprecation in an isolated child and fails if DEP0169 is emitted. It fails against current main at src/index.ts:307 and passes with this change.

Verification:
- Node 22.23.2
- TypeScript compile with repository dependencies
- unit tests: 35 passing
- git diff --check